### PR TITLE
accommodated the effect on "root" that removing undocumented

### DIFF
--- a/core/optic/shared/src/main/scala/com/useoptic/ux/DiffResultHelper.scala
+++ b/core/optic/shared/src/main/scala/com/useoptic/ux/DiffResultHelper.scala
@@ -76,7 +76,8 @@ object DiffResultHelper {
         case (diff, interactionPointers) => getLocationForDiff(diff, rfcState).map(location => {
           EndpointDiffs(location.method, location.pathId,  Map(diff -> interactionPointers), diffs.filterKeys(_.normalize() == diff), true)
         })
-      }.groupBy(i => (i.pathId, i.method)).map {
+      }.filterNot(i => i.pathId == "root")
+        .groupBy(i => (i.pathId, i.method)).map {
         case ((path, method), diffs) => {
           val diffsForThisOne = diffs.flatMap(_.diffs).toMap
           val isADocumentedEndpoint = allEndpoints.exists(i => i.pathId == path && i.method == method)

--- a/workspace/packages/domain-types/package.json
+++ b/workspace/packages/domain-types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@useoptic/domain-types",
-  "version": "10.0.10",
+  "version": "10.0.11",
   "scripts": {
     "ws:clean": "rm -rf build/*",
     "ws:build": "yarn run tsc -b --verbose && yarn run ws:copy-files",

--- a/workspace/packages/domain-utilities/package.json
+++ b/workspace/packages/domain-utilities/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@useoptic/domain-utilities",
-  "version": "10.0.10",
+  "version": "10.0.11",
   "scripts": {
     "ws:clean": "rm -rf build/*",
     "ws:build": "yarn run tsc -b --verbose",
@@ -14,8 +14,8 @@
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "dependencies": {
-    "@useoptic/domain": "10.0.10",
-    "@useoptic/domain-types": "10.0.10"
+    "@useoptic/domain": "10.0.11",
+    "@useoptic/domain-types": "10.0.11"
   },
   "devDependencies": {},
   "files": [

--- a/workspace/packages/domain/package.json
+++ b/workspace/packages/domain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@useoptic/domain",
-  "version": "10.0.10",
+  "version": "10.0.11",
   "scripts": {
     "ws:test": "echo domain",
     "ws:build": "yarn run tsc -b --verbose && yarn run ws:copy-files",


### PR DESCRIPTION
Removing the notion of "undocumented" changes how Optic will display traffic to the root path. This makes sure those don't show up unless they are, in-fact, documented 