### PR TITLE
Fixed last field resolver

### DIFF
--- a/workspace/packages/domain-types/package.json
+++ b/workspace/packages/domain-types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@useoptic/domain-types",
-  "version": "10.0.48",
+  "version": "10.0.49",
   "scripts": {
     "ws:clean": "rm -rf build/*",
     "ws:build": "yarn run tsc -b --verbose && yarn run ws:copy-files",

--- a/workspace/packages/domain-utilities/package.json
+++ b/workspace/packages/domain-utilities/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@useoptic/domain-utilities",
-  "version": "10.0.48",
+  "version": "10.0.49",
   "scripts": {
     "ws:clean": "rm -rf build/*",
     "ws:build": "yarn run tsc -b --verbose",
@@ -14,8 +14,8 @@
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "dependencies": {
-    "@useoptic/domain": "10.0.48",
-    "@useoptic/domain-types": "10.0.48"
+    "@useoptic/domain": "10.0.49",
+    "@useoptic/domain-types": "10.0.49"
   },
   "devDependencies": {},
   "files": [

--- a/workspace/packages/domain/package.json
+++ b/workspace/packages/domain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@useoptic/domain",
-  "version": "10.0.48",
+  "version": "10.0.49",
   "scripts": {
     "ws:test": "echo domain",
     "ws:build": "yarn run tsc -b --verbose && yarn run ws:copy-files",


### PR DESCRIPTION
The new UI expects to render every diff in the context of the field that changed, the listItem that changed or the root shap changing. 

The logic to go from Shape Trail -> fieldId was broken here whenever the field was optional meaning that optional fields would never change. 
